### PR TITLE
Add Phaser-based gravity sandbox skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# marlow
+# Gravity Sandbox
+
+A simple Phaser-based gravity sandbox demo. Toggle between interacting with objects and placing new materials.
+
+## Setup
+
+```bash
+npm install
+npm start
+```
+
+Then open the provided URL in a browser or mobile device.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Gravity Sandbox</title>
+  <style>
+    body { margin:0; background:#000; }
+    #menu { position:absolute; top:0; left:0; width:100%; height:40px; background:rgba(0,0,0,0.5); color:#0f0; font-family:monospace; display:flex; align-items:center; }
+    #menu button { margin:0 5px; background:#111; color:#0f0; border:1px solid #0f0; }
+    canvas { display:block; margin-top:40px; image-rendering:pixelated; }
+    .scanlines { pointer-events:none; position:fixed; top:0; left:0; width:100%; height:100%; background:repeating-linear-gradient(transparent 0px, transparent 2px, rgba(0,0,0,0.2) 2px, rgba(0,0,0,0.2) 4px); }
+  </style>
+</head>
+<body>
+  <div id="menu">
+    <button id="modeToggle">Interact</button>
+    <div id="placeMenu" style="display:none;">
+      <button data-type="sand">Sand</button>
+      <button data-type="water">Water</button>
+      <button data-type="seed">Seed</button>
+      <button data-type="dynamite">Dynamite</button>
+      <button data-type="ball">Ball</button>
+      <button data-type="lava">Lava</button>
+      <button data-type="soil">Soil</button>
+      <button data-type="bot">Bot</button>
+      <button data-type="spring">Spring</button>
+      <button data-type="magnet">Magnet</button>
+    </div>
+  </div>
+  <div class="scanlines"></div>
+  <script src="./node_modules/phaser/dist/phaser.js"></script>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gravity-sandbox",
+  "version": "1.0.0",
+  "description": "Phaser gravity sandbox",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "npx http-server -o",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "phaser": "^3.60.0"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,134 @@
+class SandboxScene extends Phaser.Scene {
+  constructor() {
+    super('sandbox');
+    this.mode = 'interact';
+    this.currentType = 'sand';
+  }
+
+  preload() {
+    this.createTextures();
+  }
+
+  createTextures() {
+    const colors = {
+      sand: 0xcccc00,
+      water: 0x0000ff,
+      seed: 0x00ff00,
+      dynamite: 0xff0000,
+      ball: 0xffffff,
+      lava: 0xff8800,
+      soil: 0x8b4513,
+      bot: 0x00ffff,
+      spring: 0xff00ff,
+      magnet: 0xaaaaaa
+    };
+    const size = 8;
+    const gfx = this.add.graphics();
+    for (const key in colors) {
+      gfx.clear();
+      gfx.fillStyle(colors[key], 1);
+      gfx.fillRect(0, 0, size, size);
+      gfx.generateTexture(key, size, size);
+    }
+    gfx.destroy();
+  }
+
+  create() {
+    this.objects = this.physics.add.group();
+
+    this.input.on('pointerdown', pointer => {
+      if (this.mode === 'place') {
+        this.placeObject(pointer.x, pointer.y);
+      }
+    });
+
+    // automated bots
+    this.time.addEvent({ delay: 2000, callback: () => this.spawnBot(), loop: true });
+  }
+
+  placeObject(x, y) {
+    const obj = this.objects.create(x, y, this.currentType);
+    obj.setInteractive();
+    obj.body.setBounce(0.2);
+    obj.body.setCollideWorldBounds(true);
+
+    if (this.currentType === 'dynamite') {
+      this.time.delayedCall(2000, () => {
+        const blast = this.add.circle(obj.x, obj.y, 40, 0xff0000, 0.5);
+        this.physics.world.overlap(this.objects, blast, o => o.destroy());
+        obj.destroy();
+        this.time.delayedCall(200, () => blast.destroy());
+      });
+    } else if (this.currentType === 'seed') {
+      this.time.delayedCall(5000, () => {
+        const tree = this.add.rectangle(obj.x, obj.y, 10, 40, 0x00ff00);
+        this.physics.world.disable(tree);
+        obj.destroy();
+      });
+    }
+  }
+
+  spawnBot() {
+    if (this.objects.countActive() > 20) return;
+    const bot = this.objects.create(Phaser.Math.Between(0, this.game.config.width), 0, 'bot');
+    bot.body.setVelocity(Phaser.Math.Between(-50, 50), 20);
+    bot.body.setCollideWorldBounds(true);
+    bot.body.setBounce(1);
+  }
+
+  update() {
+    if (this.mode === 'interact') {
+      this.input.setDraggable(this.objects.getChildren());
+      this.input.on('drag', (pointer, gameObject, dragX, dragY) => {
+        gameObject.x = dragX;
+        gameObject.y = dragY;
+      });
+    } else {
+      this.input.setDraggable([]);
+    }
+  }
+}
+
+const config = {
+  type: Phaser.AUTO,
+  width: 375,
+  height: 667,
+  backgroundColor: '#000',
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: 300 },
+      debug: false
+    }
+  },
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH
+  },
+  scene: [SandboxScene]
+};
+
+const game = new Phaser.Game(config);
+
+// UI handlers
+const modeToggle = document.getElementById('modeToggle');
+const placeMenu = document.getElementById('placeMenu');
+modeToggle.addEventListener('click', () => {
+  const scene = game.scene.keys['sandbox'];
+  if (scene.mode === 'interact') {
+    scene.mode = 'place';
+    placeMenu.style.display = 'block';
+    modeToggle.textContent = 'Place';
+  } else {
+    scene.mode = 'interact';
+    placeMenu.style.display = 'none';
+    modeToggle.textContent = 'Interact';
+  }
+});
+
+document.querySelectorAll('#placeMenu button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const scene = game.scene.keys['sandbox'];
+    scene.currentType = btn.dataset.type;
+  });
+});


### PR DESCRIPTION
## Summary
- Replace repository contents with initial Phaser gravity sandbox setup
- Implement menu-driven mode toggle and basic placing of diverse materials
- Provide simple automated bot objects and touch-friendly interactions

## Testing
- ⚠️ `npm install` (failed: 403 Forbidden fetching http-server)
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26e2e9334832b858a78f017348287