### PR TITLE
fix: register drag handler once

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,11 @@ class SandboxScene extends Phaser.Scene {
       }
     });
 
+    this.input.on('drag', (pointer, gameObject, dragX, dragY) => {
+      gameObject.x = dragX;
+      gameObject.y = dragY;
+    });
+
     // automated bots
     this.time.addEvent({ delay: 2000, callback: () => this.spawnBot(), loop: true });
   }
@@ -79,10 +84,6 @@ class SandboxScene extends Phaser.Scene {
   update() {
     if (this.mode === 'interact') {
       this.input.setDraggable(this.objects.getChildren());
-      this.input.on('drag', (pointer, gameObject, dragX, dragY) => {
-        gameObject.x = dragX;
-        gameObject.y = dragY;
-      });
     } else {
       this.input.setDraggable([]);
     }


### PR DESCRIPTION
## Summary
- register drag handler once in `create` to avoid stacking listeners

## Testing
- ⚠️ `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/http-server)
- ✅ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26f92c0cc832b82f25cb221761726