### PR TITLE
Add day-night cycle and improve object placement menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     body { margin:0; background:#000; }
     #menu { position:absolute; top:0; left:0; width:100%; height:40px; background:rgba(0,0,0,0.5); color:#0f0; font-family:monospace; display:flex; align-items:center; }
     #menu button { margin:0 5px; background:#111; color:#0f0; border:1px solid #0f0; }
+    #modeToggle { padding:8px 16px; font-size:16px; }
     canvas { display:block; margin-top:40px; image-rendering:pixelated; }
     .scanlines { pointer-events:none; position:fixed; top:0; left:0; width:100%; height:100%; background:repeating-linear-gradient(transparent 0px, transparent 2px, rgba(0,0,0,0.2) 2px, rgba(0,0,0,0.2) 4px); }
   </style>


### PR DESCRIPTION
## Summary
- Enlarge the interact button for easier tapping.
- Ensure place menu lets objects be placed immediately and doesn't trigger game actions.
- Introduce dynamic sky with sun and moon cycling over five minutes.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b283acfe08832ba3a70e384e0bf2e5