### PR TITLE
feat: enlarge menu with emoji icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,30 @@
   <title>Gravity Sandbox</title>
   <style>
     body { margin:0; background:#87ceeb; }
-    #menu { position:absolute; top:0; left:0; width:100%; height:40px; background:rgba(0,0,0,0.5); color:#0f0; font-family:monospace; display:flex; align-items:center; }
-    #menu button { margin:0 5px; background:#111; color:#0f0; border:1px solid #0f0; }
-    #menu button.active { background:#0f0; color:#111; }
-    #modeMenu button { padding:8px 16px; font-size:16px; }
-    #placeMenu { display:flex; }
-    canvas { display:block; margin-top:40px; image-rendering:pixelated; }
+      #menu {
+        position:absolute;
+        top:0;
+        left:0;
+        width:100%;
+        height:80px;
+        background:rgba(0,0,0,0.5);
+        color:#0f0;
+        font-family:monospace;
+        display:flex;
+        align-items:center;
+      }
+      #menu button {
+        margin:0 5px;
+        background:#111;
+        color:#0f0;
+        border:1px solid #0f0;
+        font-size:32px;
+        padding:16px;
+      }
+      #menu button.active { background:#0f0; color:#111; }
+      #modeMenu button { padding:16px 24px; font-size:32px; }
+      #placeMenu { display:flex; }
+      canvas { display:block; margin-top:80px; image-rendering:pixelated; }
     .scanlines { pointer-events:none; position:fixed; top:0; left:0; width:100%; height:100%; background:repeating-linear-gradient(transparent 0px, transparent 2px, rgba(0,0,0,0.2) 2px, rgba(0,0,0,0.2) 4px); }
   </style>
 </head>
@@ -20,18 +38,18 @@
       <button data-mode="place" class="active">Place</button>
       <button data-mode="interact">Interact</button>
     </div>
-    <div id="placeMenu">
-      <button data-type="sand">Sand</button>
-      <button data-type="water">Water</button>
-      <button data-type="seed">Seed</button>
-      <button data-type="dynamite">Dynamite</button>
-      <button data-type="ball">Ball</button>
-      <button data-type="lava">Lava</button>
-      <button data-type="soil">Soil</button>
-      <button data-type="bot">Bot</button>
-      <button data-type="spring">Spring</button>
-      <button data-type="magnet">Magnet</button>
-    </div>
+      <div id="placeMenu">
+        <button data-type="sand">🏖️</button>
+        <button data-type="water">💧</button>
+        <button data-type="seed">🌱</button>
+        <button data-type="dynamite">🧨</button>
+        <button data-type="ball">⚽</button>
+        <button data-type="lava">🌋</button>
+        <button data-type="soil">🟫</button>
+        <button data-type="bot">🤖</button>
+        <button data-type="spring">🌀</button>
+        <button data-type="magnet">🧲</button>
+      </div>
   </div>
   <div class="scanlines"></div>
   <script src="./node_modules/phaser/dist/phaser.js"></script>


### PR DESCRIPTION
## Summary
- increase menu height and button size for better accessibility
- replace material labels with emoji icons to save space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28bec5f14832b8d453f0eb40926b8