### PR TITLE
Enhance sandbox UI and environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       touch-action:manipulation;
       user-select:none;
     }
-    #menu button.active { background:#0ff; color:#111; }
+    #menu button.active { background:#0ff; color:#111; box-shadow:0 0 10px #0ff; }
     #menu button:disabled { opacity:0.3; }
     #menu button:active:not(:disabled) { transform:scale(0.95); filter:brightness(1.2); }
     #placeMenu { display:flex; }
@@ -37,7 +37,7 @@
 </head>
 <body>
   <div id="menu">
-    <button id="modeToggle" class="active">Mode: Place</button>
+    <button id="modeToggle" class="active">Place</button>
     <div id="placeMenu">
       <button data-type="sand">🏖️</button>
       <button data-type="water">💧</button>


### PR DESCRIPTION
## Summary
- Simplify mode toggle to display "Place" or "Interact" with corresponding activation state
- Make palette buttons mutually exclusive with glowing active state
- Add animated sky gradient and sand horizon for the sandbox backdrop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31d7a1a18832b903716098929d064