### PR TITLE
Fix Phaser loading via CDN to avoid 404 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,8 @@
     </div>
   </div>
   <div class="scanlines"></div>
-  <script src="./node_modules/phaser/dist/phaser.js"></script>
+  <!-- Load Phaser from CDN to avoid missing local dependency issues -->
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.js"></script>
   <script type="module" src="src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Phaser from CDN so the game works on GitHub Pages.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32594ad1c832ba1e4e645e268e95e