### PR TITLE
refactor ui layout and remove crt overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,54 +4,59 @@
   <meta charset="UTF-8">
   <title>Gravity Sandbox</title>
   <style>
-    body { margin:0; background:#000; color:#0ff; }
+    body { margin:0; background:#000; }
     #menu {
       position:absolute;
       top:0;
       left:0;
       width:100%;
-      height:80px;
       background:rgba(10,10,25,0.8);
-      font-family:'Courier New', monospace;
       display:flex;
+      flex-direction:column;
+      font-family:sans-serif;
       align-items:center;
     }
+    #modeToggle { width:100%; }
+    .menu-row {
+      display:flex;
+      justify-content:center;
+      width:100%;
+    }
     #menu button {
-      margin:0 5px;
-      background:#111;
-      color:#0ff;
-      border:2px solid #0ff;
+      margin:4px;
+      background:#222;
+      color:#fff;
+      border:2px solid #fff;
       font-size:32px;
       padding:16px;
       border-radius:4px;
       touch-action:manipulation;
       user-select:none;
     }
-    #menu button.active { background:#0ff; color:#111; box-shadow:0 0 10px #0ff; }
+    #menu button.active { background:#fff; color:#000; }
     #menu button:disabled { opacity:0.3; }
-    #menu button:active:not(:disabled) { transform:scale(0.95); filter:brightness(1.2); }
-    #placeMenu { display:flex; }
-    canvas { display:block; margin-top:80px; image-rendering:pixelated; }
-    .scanlines { pointer-events:none; position:fixed; top:0; left:0; width:100%; height:100%; background:repeating-linear-gradient(transparent 0px, transparent 2px, rgba(0,0,0,0.2) 2px, rgba(0,0,0,0.2) 4px); }
+    canvas { display:block; margin-top:180px; image-rendering:pixelated; }
   </style>
 </head>
 <body>
   <div id="menu">
     <button id="modeToggle" class="active">Place</button>
-    <div id="placeMenu">
-      <button data-type="sand">🏖️</button>
-      <button data-type="water">💧</button>
-      <button data-type="seed">🌱</button>
+    <div id="objectMenu" class="menu-row">
       <button data-type="dynamite">🧨</button>
+      <button data-type="seed">🌱</button>
       <button data-type="ball">⚽</button>
-      <button data-type="lava">🌋</button>
-      <button data-type="soil">🟫</button>
       <button data-type="bot">🤖</button>
       <button data-type="spring">🌀</button>
       <button data-type="magnet">🧲</button>
     </div>
+    <div id="materialMenu" class="menu-row">
+      <button data-type="sand">🏖️</button>
+      <button data-type="water">💧</button>
+      <button data-type="lava">🌋</button>
+      <button data-type="soil">🟫</button>
+    </div>
   </div>
-  <div class="scanlines"></div>
+  <!-- Removed CRT scanline overlay for cleaner pixels -->
   <!-- Load Phaser from CDN to avoid missing local dependency issues -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.js"></script>
   <script type="module" src="src/main.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -89,8 +89,6 @@ class SandboxScene extends Phaser.Scene {
       gameObject.y = dragY;
     });
 
-    // automated bots
-    this.time.addEvent({ delay: 2000, callback: () => this.spawnBot(), loop: true });
   }
 
   placeObject(x, y) {
@@ -123,14 +121,6 @@ class SandboxScene extends Phaser.Scene {
         obj.destroy();
       });
     }
-  }
-
-  spawnBot() {
-    if (this.objects.countActive() > 20) return;
-    const bot = this.objects.create(Phaser.Math.Between(0, this.game.config.width), 0, 'bot');
-    bot.body.setVelocity(Phaser.Math.Between(-50, 50), 20);
-    bot.body.setCollideWorldBounds(true);
-    bot.body.setBounce(1);
   }
 
   stepSimulation() {
@@ -282,9 +272,12 @@ const config = {
 const game = new Phaser.Game(config);
 
 // UI handlers
-const placeMenu = document.getElementById('placeMenu');
 const modeToggle = document.getElementById('modeToggle');
-const materialButtons = document.querySelectorAll('#placeMenu button');
+const objectButtons = document.querySelectorAll('#objectMenu button');
+const materialButtons = document.querySelectorAll('#materialMenu button');
+const allButtons = [...objectButtons, ...materialButtons];
+let activeButton = allButtons[0];
+activeButton.classList.add('active');
 
 modeToggle.addEventListener('pointerdown', () => {
   const scene = game.scene.keys['sandbox'];
@@ -292,25 +285,24 @@ modeToggle.addEventListener('pointerdown', () => {
     scene.mode = 'interact';
     modeToggle.textContent = 'Interact';
     modeToggle.classList.remove('active');
-    materialButtons.forEach(b => b.disabled = true);
+    allButtons.forEach(b => b.disabled = true);
   } else {
     scene.mode = 'place';
     modeToggle.textContent = 'Place';
     modeToggle.classList.add('active');
-    materialButtons.forEach(b => b.disabled = false);
-    const active = placeMenu.querySelector('button.active') || placeMenu.querySelector('button');
-    scene.currentType = active.dataset.type;
+    allButtons.forEach(b => b.disabled = false);
+    scene.currentType = activeButton.dataset.type;
   }
 });
 
-materialButtons.forEach(btn => {
+allButtons.forEach(btn => {
   btn.addEventListener('pointerdown', () => {
-    materialButtons.forEach(b => b.classList.remove('active'));
+    allButtons.forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
+    activeButton = btn;
     const scene = game.scene.keys['sandbox'];
     scene.currentType = btn.dataset.type;
   });
 });
-materialButtons[0].classList.add('active');
 
 document.getElementById('menu').addEventListener('pointerdown', e => e.stopPropagation());


### PR DESCRIPTION
## Summary
- remove CRT-style scanline overlay
- redesign menu into top toggle plus object and material rows
- drop automatic spawning of bouncing bots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32e249f50832b85d8a3f5cc879268