### PR TITLE
Add materials and physics rules for cellular world

### DIFF
--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -1,0 +1,24 @@
+import Phaser from "phaser";
+import { SUBSTEPS, RENDER_SCALE, CELL_PX } from "../sim/materials";
+import { substep } from "../sim/physicsRules";
+import { createGrid } from "../sim/grid"; // your grid impl
+
+export default class Game extends Phaser.Scene {
+  private grid = createGrid(/* width, height */);
+
+  create() {
+    // Remove CRT overlay if you had one; keep crisp pixels:
+    this.cameras.main.setZoom(RENDER_SCALE);
+    this.game.canvas.style.imageRendering = "pixelated";
+    this.game.canvas.style.imageRendering = "crisp-edges";
+    // Ensure no auto-spawn: start with an empty stable world.
+  }
+
+  update(time: number, deltaMs: number) {
+    const dt = Math.min(1/60, deltaMs/1000);
+    const step = dt / SUBSTEPS;
+    for (let i=0; i<SUBSTEPS; i++) substep(this.grid, step);
+
+    // your draw pass here: iterate grid and blit 2×2 px quads per cell
+  }
+}

--- a/src/sim/materials.ts
+++ b/src/sim/materials.ts
@@ -1,0 +1,96 @@
+// Material types and baseline physics for a pixel/destructible world.
+// Cell scale is 2 px; engine renders at 3x with nearest-neighbor.
+
+export type MaterialState = "granular" | "solid" | "liquid" | "gas" | "reactive";
+
+export interface Material {
+  key: MaterialKey;
+  state: MaterialState;
+
+  // bulk properties
+  density: number;           // relative kg/m^3
+  viscosity?: number;        // relative Pa·s (liquids)
+  surfaceTension?: number;   // 0..1
+  permeability?: number;     // 0..1 for granular
+  cohesion?: number;         // 0..1 (granular stickiness)
+  muStatic?: number;         // static friction (solids & rigid)
+  muDynamic?: number;        // kinetic friction
+  restitution?: number;      // bounciness 0..1
+
+  // thermal (optional)
+  temp?: number;             // current °C
+  ignitionTemp?: number;     // °C
+  burnRate?: number;         // 0..1 per second
+  evapTemp?: number;         // °C (liquids -> gas)
+  evapRate?: number;         // 0..1 per second
+  condenseTemp?: number;     // °C (gas -> liquid)
+  coolToStoneTemp?: number;  // °C (lava -> stone)
+  fadeRate?: number;         // 0..1 per second (smoke)
+}
+
+export type MaterialKey =
+  | "SAND" | "DIRT" | "STONE" | "WOOD" | "WATER"
+  | "OIL" | "LAVA" | "FIRE" | "STEAM" | "SMOKE";
+
+export const CELL_PX = 2;               // pixel size per cell
+export const RENDER_SCALE = 3;          // canvas scale; keep nearest-neighbor
+export const GRAVITY_PX = 980;          // px/s^2 at this scale
+export const SUBSTEPS = 4;              // 60 FPS * 4 = 240 Hz solver
+
+// Default thermal constants (engine-wide)
+export const AMBIENT_TEMP = 20;
+export const WATER_BOIL = 100;
+export const WATER_CONDENSE = 95;
+export const LAVA_TEMP = 1200;
+
+export const MATERIALS: Record<MaterialKey, Material> = {
+  SAND: {
+    key: "SAND", state: "granular",
+    density: 1600, cohesion: 0.05, permeability: 0.65,
+    viscosity: 0.02, restitution: 0.05, muStatic: 0.60, muDynamic: 0.45
+  },
+  DIRT: {
+    key: "DIRT", state: "granular",
+    density: 1400, cohesion: 0.15, permeability: 0.45,
+    viscosity: 0.03, restitution: 0.03, muStatic: 0.70, muDynamic: 0.50
+  },
+  STONE: {
+    key: "STONE", state: "solid",
+    density: 2600, muStatic: 0.80, muDynamic: 0.65, restitution: 0.02
+  },
+  WOOD: {
+    key: "WOOD", state: "solid",
+    density: 600, muStatic: 0.55, muDynamic: 0.45, restitution: 0.10,
+    ignitionTemp: 560, burnRate: 0.015
+  },
+  WATER: {
+    key: "WATER", state: "liquid",
+    density: 1000, viscosity: 1.0, surfaceTension: 0.35,
+    evapTemp: WATER_BOIL, evapRate: 0.002
+  },
+  OIL: {
+    key: "OIL", state: "liquid",
+    density: 850, viscosity: 6.0, surfaceTension: 0.25,
+    ignitionTemp: 310, burnRate: 0.02
+  },
+  LAVA: {
+    key: "LAVA", state: "liquid",
+    density: 2700, viscosity: 80.0, surfaceTension: 0.50,
+    temp: LAVA_TEMP, coolToStoneTemp: 700
+  },
+  FIRE: {
+    key: "FIRE", state: "reactive",
+    density: 0.1,          // rises fast
+    fadeRate: 0.0,         // fire converts to SMOKE/STEAM, not just fade
+    temp: 900, burnRate: 1 // heat source; lifespan handled by fuel
+  },
+  STEAM: {
+    key: "STEAM", state: "gas",
+    density: 0.6, viscosity: 0.1,
+    condenseTemp: WATER_CONDENSE, evapRate: 0.0, fadeRate: 0.0
+  },
+  SMOKE: {
+    key: "SMOKE", state: "gas",
+    density: 0.4, viscosity: 0.2, fadeRate: 0.01
+  }
+};

--- a/src/sim/physicsRules.ts
+++ b/src/sim/physicsRules.ts
@@ -1,0 +1,213 @@
+import { MATERIALS, MaterialKey, GRAVITY_PX } from "./materials";
+
+// Core, deterministic cell-step rules for each substep.
+// Assumes a grid-based world with get/set helpers and integer cell coords.
+
+export interface Cell {
+  mat: MaterialKey;
+  temp: number;
+  vx: number; // optional per-cell drift (for gases/liquids)
+  vy: number;
+  // moisture flag could be added to boost SAND/DRT cohesion when wet
+}
+
+export interface Grid {
+  width: number; height: number;
+  get(x: number, y: number): Cell | null;
+  set(x: number, y: number, c: Cell | null): void;
+  swap(ax: number, ay: number, bx: number, by: number): void;
+  inBounds(x: number, y: number): boolean;
+}
+
+export const MAX_FALL_WATER = 100; // px/s cap inside liquids (heavy)
+export const MAX_FALL_WOOD  = 40;
+
+export function substep(grid: Grid, dt: number) {
+  updateGases(grid, dt);
+  updateLiquids(grid, dt);
+  updateGranular(grid, dt);
+  solveReactions(grid, dt);
+}
+
+// ---------- GASES ----------
+function updateGases(grid: Grid, dt: number) {
+  forEachCell(grid, (x, y, cell) => {
+    if (!cell) return;
+    if (cell.mat !== "SMOKE" && cell.mat !== "STEAM" && cell.mat !== "FIRE") return;
+
+    let riseRate = (cell.mat === "FIRE" ? 120 : cell.mat === "STEAM" ? 90 : 70); // px/s
+    let targetY = y - Math.max(1, Math.floor((riseRate * dt)));
+    // diffuse sideways randomly to avoid columns
+    let dx = Math.sign(Math.random() - 0.5);
+
+    tryMoveGas(grid, x, y, x + dx, targetY, cell);
+
+    // Smoke fades
+    if (cell.mat === "SMOKE") {
+      if (Math.random() < MATERIALS.SMOKE.fadeRate! * dt) grid.set(x, y, null);
+    }
+    // Steam condenses
+    if (cell.mat === "STEAM") {
+      const t = cell.temp ?? 100;
+      if (t < (MATERIALS.STEAM.condenseTemp ?? 95)) {
+        grid.set(x, y, { mat: "WATER", temp: 80, vx: 0, vy: 0 });
+      }
+    }
+  });
+}
+
+function tryMoveGas(grid: Grid, x:number, y:number, nx:number, ny:number, c:Cell) {
+  if (!grid.inBounds(nx, ny)) return;
+  const dest = grid.get(nx, ny);
+  if (!dest) { grid.swap(x, y, nx, ny); return; }
+  // gases displace only other gases (lighter rises through heavier)
+  if (isGas(dest.mat) && density(dest.mat) > density(c.mat)) grid.swap(x, y, nx, ny);
+}
+
+const isGas = (m:MaterialKey) => m==="SMOKE"||m==="STEAM"||m==="FIRE";
+const density = (m:MaterialKey)=> MATERIALS[m].density;
+
+// ---------- LIQUIDS ----------
+function updateLiquids(grid: Grid, dt: number) {
+  forEachCell(grid, (x, y, cell) => {
+    if (!cell) return;
+    if (cell.mat !== "WATER" && cell.mat !== "OIL" && cell.mat !== "LAVA") return;
+
+    const below = grid.get(x, y+1);
+    if (!below) { grid.swap(x, y, x, y+1); return; }
+
+    // Heavier liquid sinks under lighter liquid
+    if (isLiquid(below.mat) && density(cell.mat) > density(below.mat)) { grid.swap(x,y,x,y+1); return; }
+
+    // Spread sideways if blocked
+    const dir = Math.random() < 0.5 ? -1 : 1;
+    if (tryLiquidSlide(grid, x, y, dir)) return;
+    if (tryLiquidSlide(grid, x, y, -dir)) return;
+
+    // Drag rigid "wood-like" solids to float
+    if (isSolid(below.mat) && density(below.mat) < density("WATER")) {
+      // do nothing; liquids flow around
+    }
+  });
+}
+
+const isLiquid = (m:MaterialKey)=> m==="WATER"||m==="OIL"||m==="LAVA";
+const isSolid = (m:MaterialKey)=> m==="STONE"||m==="WOOD";
+
+function tryLiquidSlide(grid:Grid, x:number, y:number, dir:number){
+  const down = grid.get(x, y+1);
+  const sx = x + dir;
+  const sl = grid.get(sx, y);
+  const sdl = grid.get(sx, y+1);
+  if (grid.inBounds(sx,y) && !sl && !sdl) { grid.swap(x,y,sx,y); return true; }
+  if (grid.inBounds(sx,y) && !sdl) { grid.swap(x,y,sx,y+1); return true; }
+  return false;
+}
+
+// ---------- GRANULAR (SAND/DIRT) ----------
+function updateGranular(grid: Grid, dt: number) {
+  forEachCell(grid, (x, y, cell) => {
+    if (!cell) return;
+    if (cell.mat !== "SAND" && cell.mat !== "DIRT") return;
+
+    // fall straight down if empty
+    if (!grid.get(x, y+1)) { grid.swap(x, y, x, y+1); return; }
+
+    // slide around obstacles (angle of repose ~ arctan(muStatic))
+    const dir = Math.random() < 0.5 ? -1 : 1;
+    if (tryGranularSlide(grid, x, y, dir)) return;
+    if (tryGranularSlide(grid, x, y, -dir)) return;
+
+    // swap with lighter liquids (sink)
+    const below = grid.get(x, y+1);
+    if (below && isLiquid(below.mat) && density(cell.mat) > density(below.mat)) {
+      grid.swap(x, y, x, y+1);
+    }
+  });
+}
+
+function tryGranularSlide(grid:Grid, x:number, y:number, dir:number){
+  const sx = x + dir;
+  const sdl = grid.get(sx, y+1);
+  if (!grid.inBounds(sx, y+1)) return false;
+  if (!sdl) { grid.swap(x, y, sx, y+1); return true; }
+  return false;
+}
+
+// ---------- REACTIONS ----------
+function solveReactions(grid: Grid, dt: number) {
+  forEachCell(grid, (x, y, c) => {
+    if (!c) return;
+
+    // LAVA + WATER => STONE + STEAM (quench)
+    if (c.mat === "LAVA") {
+      forNeighbors(grid, x, y, (nx, ny, n) => {
+        if (n?.mat === "WATER") {
+          if (Math.random() < 0.4) grid.set(x, y, { mat: "STONE", temp: 200, vx: 0, vy: 0 });
+          grid.set(nx, ny, { mat: "STEAM", temp: 100, vx: 0, vy: 0 });
+        }
+      });
+    }
+
+    // FIRE heats neighbors; consumes OIL/WOOD; creates SMOKE
+    if (c.mat === "FIRE") {
+      forNeighbors(grid, x, y, (nx, ny, n) => {
+        if (!n) return;
+        const ignite = (key:MaterialKey, t:number) =>
+          MATERIALS[key].ignitionTemp && t >= MATERIALS[key].ignitionTemp!;
+        n.temp = Math.max(n.temp ?? 0, (n.temp ?? 0) + 60 * dt);
+
+        if ((n.mat === "OIL" || n.mat === "WOOD") && ignite(n.mat, n.temp!)) {
+          // Convert cell to FIRE briefly, leave SMOKE trail
+          if (Math.random() < 0.25) grid.set(nx, ny, { mat: "FIRE", temp: 800, vx: 0, vy: -20 });
+          if (Math.random() < 0.15) grid.set(nx, ny-1, { mat: "SMOKE", temp: 120, vx: 0, vy: -10 });
+        }
+      });
+
+      // Fire self-decay if no fuel nearby
+      if (!hasCombustibleNeighbor(grid, x, y)) {
+        if (Math.random() < 0.3) grid.set(x, y, { mat: "SMOKE", temp: 120, vx: 0, vy: -10 });
+      }
+    }
+
+    // OIL near FIRE ignites
+    if (c.mat === "OIL") {
+      if (neighborIs(grid, x, y, "FIRE") && Math.random() < 0.5) {
+        grid.set(x, y, { mat: "FIRE", temp: 800, vx: 0, vy: -20 });
+      }
+    }
+
+    // STEAM cools -> WATER handled in gases update via condenseTemp
+  });
+}
+
+// ---------- Helpers ----------
+function forEachCell(grid:Grid, fn:(x:number,y:number,c:Cell|null)=>void){
+  for (let y=0; y<grid.height; y++){
+    for (let x=0; x<grid.width; x++){
+      fn(x, y, grid.get(x, y));
+    }
+  }
+}
+
+function forNeighbors(grid:Grid, x:number, y:number, fn:(nx:number,ny:number,n:Cell|null)=>void){
+  for (let dy=-1; dy<=1; dy++){
+    for (let dx=-1; dx<=1; dx++){
+      if (dx===0 && dy===0) continue;
+      const nx=x+dx, ny=y+dy;
+      if (grid.inBounds(nx, ny)) fn(nx, ny, grid.get(nx, ny));
+    }
+  }
+}
+
+function neighborIs(grid:Grid, x:number, y:number, mat:MaterialKey){
+  let ok=false;
+  forNeighbors(grid,x,y,(nx,ny,n)=>{ if(n?.mat===mat) ok=true; });
+  return ok;
+}
+
+function hasCombustibleNeighbor(grid:Grid, x:number, y:number){
+  let combustible=false;
+  forNeighbors(grid,x,y,(nx,ny,n)=>{ if(n && (n.mat==="OIL" || n.mat==="WOOD")) combustible=true; });
+  return combustible;
+}


### PR DESCRIPTION
## Summary
- Define materials config and global physics constants for 2px cell simulation
- Introduce per-cell physics rules handling gases, liquids, granular materials and reactions
- Stub Phaser Game scene wired to substep simulation and pixel-perfect rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3325e4768832bbf0a624d790972e7