### PR TITLE
Fix object placement scaling with camera zoom

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,8 @@ class SandboxScene extends Phaser.Scene {
       if (this.mode === 'place') {
         this.placing = true;
         this.pointer = pointer;
-        this.placeObject(pointer.x, pointer.y);
+        // Use world coordinates so placement aligns with camera zoom
+        this.placeObject(pointer.worldX, pointer.worldY);
         this.lastPlace = pointer.time;
       }
     });
@@ -242,7 +243,8 @@ class SandboxScene extends Phaser.Scene {
     } else {
       this.input.setDraggable([]);
       if (this.placing && this.pointer && time - this.lastPlace > 50) {
-        this.placeObject(this.pointer.x, this.pointer.y);
+        // Pointer coordinates are screen-space; convert to world-space
+        this.placeObject(this.pointer.worldX, this.pointer.worldY);
         this.lastPlace = time;
       }
     }


### PR DESCRIPTION
## Summary
- Use pointer world coordinates for object placement to account for DPR camera zoom
- Update continuous placement logic to use world coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b342ff739c832b9ee75e37b5eba3d4