### PR TITLE
Make canvas fill window and start instantly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,13 @@ const sim = new Simulation(GRID_SIZE, GRID_SIZE);
 canvas.width = GRID_SIZE;
 canvas.height = GRID_SIZE;
 
-// Scale the canvas to fit the window while preserving pixels.
-const scale = Math.min(window.innerWidth, window.innerHeight - 80) / GRID_SIZE;
-canvas.style.width = canvas.style.height = GRID_SIZE * scale + 'px';
+// Make the canvas fill the window while preserving simulation resolution.
+function resizeCanvas() {
+  canvas.style.width = window.innerWidth + 'px';
+  canvas.style.height = window.innerHeight + 'px';
+}
+resizeCanvas();
+window.addEventListener('resize', resizeCanvas);
 
 const imageData = ctx.createImageData(sim.width, sim.height);
 const pixels = imageData.data;
@@ -95,9 +99,4 @@ document.getElementById('pause').addEventListener('click', () => {
 
 document.getElementById('clear').addEventListener('click', () => {
   sim.clear();
-});
-
-window.addEventListener('resize', () => {
-  // resizing a running simulation is complex; easiest is to reload
-  location.reload();
 });

--- a/styles.css
+++ b/styles.css
@@ -3,13 +3,14 @@ body {
   background: #222;
   color: #fff;
   font-family: sans-serif;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  overflow: hidden;
 }
 
 #ui {
-  margin: 0.5rem;
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1;
 }
 
 #tools button {
@@ -17,6 +18,9 @@ body {
 }
 
 canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
   background: #000;
   image-rendering: pixelated;
   touch-action: none;


### PR DESCRIPTION
## Summary
- Expand canvas to cover full browser window and adjust size on resize for responsive play area.
- Overlay control UI using absolute positioning so menu is always visible.
- Remove reload-on-resize to keep simulation running and start immediately on load.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60fff542c832b9cc712986afa4323