### PR TITLE
Polish menu bar and tweak material behaviors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ const pixels = imageData.data;
 
 let current = Element.Sand;
 let paused = false;
+const BRUSH_RADIUS = 1;
 
 function render() {
   for (let i = 0; i < sim.size; i++) {
@@ -51,9 +52,16 @@ function pointerPos(evt) {
 
 function draw(evt) {
   const { x, y } = pointerPos(evt);
-  sim.set(x, y, current);
-  if (current === Element.Fire) sim.setLife(x, y, 5);
-  if (current === Element.Smoke) sim.setLife(x, y, 10);
+  for (let dx = -BRUSH_RADIUS; dx <= BRUSH_RADIUS; dx++) {
+    for (let dy = -BRUSH_RADIUS; dy <= BRUSH_RADIUS; dy++) {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!sim.inBounds(nx, ny)) continue;
+      sim.set(nx, ny, current);
+      if (current === Element.Fire) sim.setLife(nx, ny, 5);
+      if (current === Element.Smoke) sim.setLife(nx, ny, 10);
+    }
+  }
 }
 
 let drawing = false;

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -108,7 +108,7 @@ export class Simulation {
         const nx = x + d;
         if (nx < 0 || nx >= w) continue;
         const n = idx + d;
-        if (front[n] === Element.Empty) {
+        if (front[n] === Element.Empty && rnd() < 0.5) {
           move(idx, n, Element.Water);
           return;
         }

--- a/styles.css
+++ b/styles.css
@@ -8,13 +8,35 @@ body {
 
 #ui {
   position: absolute;
-  top: 0.5rem;
-  left: 0.5rem;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.5);
+  box-sizing: border-box;
   z-index: 1;
 }
 
-#tools button {
-  margin-right: 0.25rem;
+#tools {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#ui button {
+  background: #444;
+  color: #fff;
+  border: 1px solid #666;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#ui button:hover {
+  background: #555;
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- Make UI toolbar span the full screen width with styled buttons for a more polished look
- Draw materials using a small brush to increase placement flow
- Slow horizontal movement of water so it pools on the ground longer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b622129d5c832ba5d8068d232b11c6