### PR TITLE
Expand top menu to full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,10 @@
 <body>
   <div id="ui">
     <div id="tools"></div>
-    <button id="pause">Pause</button>
-    <button id="clear">Clear</button>
+    <div id="actions">
+      <button id="pause">Pause</button>
+      <button id="clear">Clear</button>
+    </div>
   </div>
   <canvas id="world"></canvas>
   <script type="module" src="src/main.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -12,8 +12,8 @@ body {
   left: 0;
   width: 100%;
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   padding: 0.5rem;
   background: rgba(0, 0, 0, 0.5);
@@ -22,6 +22,17 @@ body {
 }
 
 #tools {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 0.5rem;
+}
+
+#tools button {
+  width: 100%;
+}
+
+#actions {
   display: flex;
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Redesign top menu layout so it spans the entire window width
- Group action buttons and use a responsive grid for tool buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f44b774c832b854b5ed0d43d1b2d