### PR TITLE
Streamlined menu with material selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,11 @@
 </head>
 <body>
   <canvas id="world"></canvas>
+  <div id="materials" class="hidden"></div>
   <div id="menu">
-    <div id="materials"></div>
-    <div id="actions">
-      <label for="brush">Brush Size</label>
-      <input id="brush" type="range" min="1" max="10" value="1" />
-      <button id="pause">Pause</button>
-      <button id="clear">Clear</button>
-    </div>
+    <button id="brush">Brush: 1</button>
+    <button id="clear">Clear</button>
+    <button id="material-button">Material</button>
   </div>
   <script type="module" src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -21,8 +21,9 @@ const imageData = ctx.createImageData(sim.width, sim.height);
 const pixels = imageData.data;
 
 let current = Element.Sand;
-let paused = false;
-let brushRadius = 1;
+const BRUSH_SIZES = [1, 2, 4, 8];
+let brushIndex = 0;
+let brushRadius = BRUSH_SIZES[brushIndex];
 
 function render() {
   for (let i = 0; i < sim.size; i++) {
@@ -37,7 +38,7 @@ function render() {
 }
 
 function loop() {
-  if (!paused) sim.step();
+  sim.step();
   render();
   requestAnimationFrame(loop);
 }
@@ -84,6 +85,9 @@ window.addEventListener('touchend', () => (drawing = false));
 
 // UI controls
 const materials = document.getElementById('materials');
+const materialBtn = document.getElementById('material-button');
+const brushBtn = document.getElementById('brush');
+
 const materialDefs = [
   { name: 'Sand', elem: Element.Sand, emoji: '🟫' },
   { name: 'Water', elem: Element.Water, emoji: '💧' },
@@ -102,16 +106,19 @@ for (const { name, elem, emoji } of materialDefs) {
   btn.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
   btn.addEventListener('click', () => {
     current = elem;
+    materials.classList.add('hidden');
   });
   materials.appendChild(btn);
 }
 
-document.getElementById('brush').addEventListener('input', (e) => {
-  brushRadius = parseInt(e.target.value, 10);
+materialBtn.addEventListener('click', () => {
+  materials.classList.toggle('hidden');
 });
 
-document.getElementById('pause').addEventListener('click', () => {
-  paused = !paused;
+brushBtn.addEventListener('click', () => {
+  brushIndex = (brushIndex + 1) % BRUSH_SIZES.length;
+  brushRadius = BRUSH_SIZES[brushIndex];
+  brushBtn.textContent = `Brush: ${brushRadius}`;
 });
 
 document.getElementById('clear').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -17,19 +17,44 @@ canvas {
 }
 
 #menu {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
   background: rgba(0, 0, 0, 0.8);
 }
 
+#menu button {
+  background: #444;
+  color: #fff;
+  border: 1px solid #666;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#menu button:hover {
+  background: #555;
+}
+
+#material-button {
+  margin-left: auto;
+}
+
 #materials {
+  position: fixed;
+  bottom: 60px;
+  right: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  flex: 1;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 0.5rem;
+  border-radius: 4px;
 }
 
 #materials button {
@@ -44,25 +69,6 @@ canvas {
   font-size: 20px;
 }
 
-#actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-#actions button {
-  background: #444;
-  color: #fff;
-  border: 1px solid #666;
-  padding: 0.4rem 0.75rem;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-#actions button:hover {
-  background: #555;
-}
-
-#brush {
-  width: 80px;
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- Replace complex menu with three buttons: Material selector, brush-size toggle, and clear sandbox
- Add material picker popup and cyclic brush sizes
- Position Material button at bottom-right for thumb access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4fcca9944832b9143b1cbb7e053b4