### PR TITLE
Ensure materials palette toggles and adjust sandbox layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <div id="menu">
     <button id="brush">Brush: 1</button>
     <button id="clear">Clear</button>
-    <button id="material-button">Material</button>
+    <button id="material-button">Materials</button>
   </div>
   <script type="module" src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,10 @@ import { Element, COLORS } from './elements.js';
 
 const canvas = document.getElementById('world');
 const ctx = canvas.getContext('2d');
+const menu = document.getElementById('menu');
+const materials = document.getElementById('materials');
+const materialBtn = document.getElementById('material-button');
+const brushBtn = document.getElementById('brush');
 
 const GRID_SIZE = window.innerWidth < 600 ? 150 : 200;
 const sim = new Simulation(GRID_SIZE, GRID_SIZE);
@@ -11,8 +15,10 @@ canvas.height = GRID_SIZE;
 
 // Make the canvas fill the available space while preserving simulation resolution.
 function resizeCanvas() {
+  const menuHeight = menu.offsetHeight;
   canvas.style.width = '100%';
-  canvas.style.height = '100%';
+  canvas.style.height = `${window.innerHeight - menuHeight}px`;
+  materials.style.bottom = `${menuHeight + 10}px`;
 }
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
@@ -82,11 +88,6 @@ canvas.addEventListener('touchmove', (e) => {
   e.preventDefault();
 });
 window.addEventListener('touchend', () => (drawing = false));
-
-// UI controls
-const materials = document.getElementById('materials');
-const materialBtn = document.getElementById('material-button');
-const brushBtn = document.getElementById('brush');
 
 const materialDefs = [
   { name: 'Sand', elem: Element.Sand, emoji: '🟫' },

--- a/styles.css
+++ b/styles.css
@@ -10,10 +10,10 @@ body {
 }
 
 canvas {
-  flex: 1;
   background: #000;
   image-rendering: pixelated;
   touch-action: none;
+  display: block;
 }
 
 #menu {
@@ -51,7 +51,7 @@ canvas {
 
 #materials {
   position: fixed;
-  bottom: 100px;
+  bottom: 10px;
   right: 10px;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Rename the Material button and ensure its panel toggles visibility
- Calculate canvas height to sit above menu and reposition materials palette
- Remove flex sizing on canvas for reliable layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5aabe77bc832ba306da2eb32f7d1f