### PR TITLE
Add spark-based fire effects and toggleable material menu

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -15,6 +15,7 @@ export const Element = Object.freeze({
   Seed: 8,
   Flower: 9,
   Tree: 10,
+  Spark: 11,
 });
 
 /**
@@ -27,6 +28,7 @@ export const COLORS = {
   [Element.Water]: [64, 164, 223, 255],
   [Element.Wall]: [120, 120, 120, 255],
   [Element.Fire]: [255, 85, 0, 255],
+  [Element.Spark]: [255, 200, 50, 255],
   [Element.Plant]: [0, 160, 0, 255],
   [Element.Smoke]: [80, 80, 80, 150],
   [Element.Oil]: [30, 30, 30, 255],

--- a/src/main.js
+++ b/src/main.js
@@ -30,11 +30,29 @@ let current = Element.Sand;
 const BRUSH_SIZES = [1, 2, 4, 8];
 let brushIndex = 0;
 let brushRadius = BRUSH_SIZES[brushIndex];
+let materialsVisible = false;
 
 function render() {
   for (let i = 0; i < sim.size; i++) {
-    const c = COLORS[sim.front[i]];
+    const t = sim.front[i];
     const p = i * 4;
+    if (t === Element.Fire) {
+      const flicker = (Math.random() * 50) | 0;
+      pixels[p] = 255;
+      pixels[p + 1] = 100 + flicker;
+      pixels[p + 2] = flicker / 2;
+      pixels[p + 3] = 255;
+      continue;
+    }
+    if (t === Element.Spark) {
+      const flicker = (Math.random() * 80) | 0;
+      pixels[p] = 255;
+      pixels[p + 1] = 180 + flicker;
+      pixels[p + 2] = 80;
+      pixels[p + 3] = 255;
+      continue;
+    }
+    const c = COLORS[t];
     pixels[p] = c[0];
     pixels[p + 1] = c[1];
     pixels[p + 2] = c[2];
@@ -121,12 +139,18 @@ for (const { name, elem, emoji } of materialDefs) {
   btn.addEventListener('click', () => {
     current = elem;
     materials.classList.add('hidden');
+    materialsVisible = false;
   });
   materials.appendChild(btn);
 }
 
 materialBtn.addEventListener('click', () => {
-  materials.classList.toggle('hidden');
+  materialsVisible = !materialsVisible;
+  materials.classList.toggle('hidden', !materialsVisible);
+  if (materialsVisible) {
+    const rect = materialBtn.getBoundingClientRect();
+    materials.style.right = `${window.innerWidth - rect.right}px`;
+  }
 });
 
 brushBtn.addEventListener('click', () => {

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -149,6 +149,10 @@ export class Simulation {
           lifeB[n] = 5;
         }
       }
+      if (Math.random() < 0.3 && y > 0 && front[idx - w] === Element.Empty) {
+        back[idx - w] = Element.Spark;
+        lifeB[idx - w] = 3;
+      }
       if (life <= 0) {
         back[idx] = Element.Smoke;
         lifeB[idx] = 5;
@@ -262,6 +266,26 @@ export class Simulation {
       lifeB[idx] = life - 1;
     };
 
+    const updateSpark = (x, y, idx) => {
+      const life = lifeF[idx];
+      if (life <= 0) {
+        back[idx] = Element.Smoke;
+        lifeB[idx] = 3;
+        return;
+      }
+      const dir = rnd() < 0.5 ? -1 : 1;
+      const nx = x + dir;
+      const up = idx - w;
+      const diag = up + dir;
+      if (y > 0 && nx >= 0 && nx < w && front[diag] === Element.Empty) {
+        move(idx, diag, Element.Spark, life - 1);
+      } else if (y > 0 && front[up] === Element.Empty) {
+        move(idx, up, Element.Spark, life - 1);
+      } else {
+        lifeB[idx] = life - 1;
+      }
+    };
+
     for (let y = yStart; y !== yEnd; y += yStep) {
       for (let x = 0; x < w; x++) {
         const idx = x + y * w;
@@ -290,6 +314,9 @@ export class Simulation {
             break;
           case Element.Smoke:
             updateSmoke(x, y, idx);
+            break;
+          case Element.Spark:
+            updateSpark(x, y, idx);
             break;
           case Element.Oil:
             updateOil(x, y, idx);


### PR DESCRIPTION
## Summary
- Add spark element and color definition to enrich fire effects
- Spawn sparks from flames and animate their upward movement with flickering colors
- Track materials submenu visibility and toggle it from the Materials button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c611c3f914832bbaca0736102d36b2